### PR TITLE
Add gitflow links

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -51,6 +51,13 @@
 * [Gists] (https://gist.github.com)
 *Mike Kavouras*
 
+######Workflows:
+* [A successful Git branching model](http://nvie.com/posts/a-successful-git-branching-model/)
+*Cameron Spickert*
+
+* [gitflow](https://github.com/nvie/gitflow)
+*Cameron Spickert*
+
 
 ###Objective-C
 ######Unit-0:


### PR DESCRIPTION
I added a couple of links related to the branching vs. forking discussion @elberdev and I had at office hours yesterday.

The first ([A successful Git branching model](http://nvie.com/posts/a-successful-git-branching-model/)) is a blog post about one way to use git on a team. The basic premise is that you use one remote repository, and you create feature branches to make changes, which eventually get merged into `develop` and then `master`.

The second ([gitflow](https://github.com/nvie/gitflow)) is a git extension that implements the branching strategy outlined in the blog post. With it installed, you can do things like `git flow feature start my-cool-feature`, which automatically creates a new feature branch with a standard prefix (e.g. `feature/my-cool-feature`). Basically, it makes it easier and less error-prone to adhere to the git flow branching model.

I know these are kind of advanced features, but I figure they might be useful later in the course. Happy to discuss these in gory detail at Wednesday office hours or on Sundays :smile:.
